### PR TITLE
fix(seatbelt): `seatbeltOn` being stuck set to true

### DIFF
--- a/client/seatbelt.lua
+++ b/client/seatbelt.lua
@@ -37,6 +37,9 @@ Citizen.CreateThread(function()
                 DisableControlAction(0, 75, true)
                 DisableControlAction(27, 75, true)
             end
+        else
+            seatbeltOn = false
+            harnessOn = false
         end
     end
 end)


### PR DESCRIPTION
The `seatbeltOn` is always stuck to true after either being ejected from the vehicle, or the vehicle is DV'ed while you're the driver. This fixes that.