### PR TITLE
disallow steering a vehicle while hands are up

### DIFF
--- a/client/handsup.lua
+++ b/client/handsup.lua
@@ -5,14 +5,26 @@ local handsup = false
 RegisterKeyMapping('hu', 'Put your hands up', 'KEYBOARD', 'X')
 
 RegisterCommand('hu', function()
+    local ped = PlayerPedId()
 	RequestAnimDict(animDict)
 	while not HasAnimDictLoaded(animDict) do
 		Citizen.Wait(100)
 	end
-    if not handsup then
-        TaskPlayAnim(PlayerPedId(), animDict, anim, 8.0, 8.0, -1, 50, 0, false, false, false)
-    else
-        ClearPedTasks(PlayerPedId())
-    end
     handsup = not handsup
+    if handsup then
+        TaskPlayAnim(ped, animDict, anim, 8.0, 8.0, -1, 50, 0, false, false, false)
+        if IsPedInAnyVehicle(ped, false) then
+            local vehicle = GetVehiclePedIsIn(ped, false)
+            if GetPedInVehicleSeat(vehicle, -1) == ped then
+                Citizen.CreateThread(function()
+                    while handsup do
+                        Citizen.Wait(1)
+                        DisableControlAction(0, 59, true) -- Disable steering in vehicle
+                    end
+                end)
+            end
+        end
+    else
+        ClearPedTasks(ped)
+    end
 end, false)


### PR DESCRIPTION
Checks if you're in a vehicle, and driving. Loop breaks once hands are no longer up.

Closes https://github.com/qbcore-framework/qb-smallresources/issues/64