### PR TITLE
Removed handsup on bikes and motorcycles

### DIFF
--- a/client/handsup.lua
+++ b/client/handsup.lua
@@ -10,21 +10,24 @@ RegisterCommand('hu', function()
 	while not HasAnimDictLoaded(animDict) do
 		Citizen.Wait(100)
 	end
-    handsup = not handsup
-    if handsup then
-        TaskPlayAnim(ped, animDict, anim, 8.0, 8.0, -1, 50, 0, false, false, false)
-        if IsPedInAnyVehicle(ped, false) then
-            local vehicle = GetVehiclePedIsIn(ped, false)
-            if GetPedInVehicleSeat(vehicle, -1) == ped then
-                Citizen.CreateThread(function()
-                    while handsup do
-                        Citizen.Wait(1)
-                        DisableControlAction(0, 59, true) -- Disable steering in vehicle
-                    end
-                end)
+    vehicle = GetVehiclePedIsIn(ped)
+    if GetVehicleClass(vehicle) ~= 8 and GetVehicleClass(vehicle) ~= 13 then
+        handsup = not handsup
+        if handsup then
+            TaskPlayAnim(ped, animDict, anim, 8.0, 8.0, -1, 50, 0, false, false, false)
+            if IsPedInAnyVehicle(ped, false) then
+                local vehicle = GetVehiclePedIsIn(ped, false)
+                if GetPedInVehicleSeat(vehicle, -1) == ped then
+                    Citizen.CreateThread(function()
+                        while handsup do
+                            Citizen.Wait(1)
+                            DisableControlAction(0, 59, true) -- Disable steering in vehicle
+                        end
+                    end)
+                end
             end
+        else
+            ClearPedTasks(ped)
         end
-    else
-        ClearPedTasks(ped)
     end
 end, false)

--- a/client/handsup.lua
+++ b/client/handsup.lua
@@ -29,6 +29,7 @@ RegisterCommand('hu', function()
             elseif IsPedClimbing(ped) then
                 Citizen.Wait(200)
                 SetPedToRagdoll(ped, 1500, 2000, 0, 0.0, 0.0, 0.0)
+        	handsup = not handsup
             end
         else
             ClearPedTasks(ped)

--- a/client/handsup.lua
+++ b/client/handsup.lua
@@ -1,5 +1,5 @@
 local animDict = "missminuteman_1ig_2"
-local anim = "handsup_enter"
+local anim = "handsup_base"
 local handsup = false
 
 RegisterKeyMapping('hu', 'Put your hands up', 'KEYBOARD', 'X')
@@ -8,23 +8,27 @@ RegisterCommand('hu', function()
     local ped = PlayerPedId()
 	RequestAnimDict(animDict)
 	while not HasAnimDictLoaded(animDict) do
-		Citizen.Wait(100)
+		Wait(100)
 	end
     vehicle = GetVehiclePedIsIn(ped)
     if GetVehicleClass(vehicle) ~= 8 and GetVehicleClass(vehicle) ~= 13 then
         handsup = not handsup
+        if exports['qb-policejob']:IsHandcuffed() then return end
         if handsup then
             TaskPlayAnim(ped, animDict, anim, 8.0, 8.0, -1, 50, 0, false, false, false)
             if IsPedInAnyVehicle(ped, false) then
                 local vehicle = GetVehiclePedIsIn(ped, false)
                 if GetPedInVehicleSeat(vehicle, -1) == ped then
-                    Citizen.CreateThread(function()
+                    CreateThread(function()
                         while handsup do
-                            Citizen.Wait(1)
+                            Wait(1)
                             DisableControlAction(0, 59, true) -- Disable steering in vehicle
                         end
                     end)
                 end
+            elseif IsPedClimbing(ped) then
+                Citizen.Wait(200)
+                SetPedToRagdoll(ped, 1500, 2000, 0, 0.0, 0.0, 0.0)
             end
         else
             ClearPedTasks(ped)


### PR DESCRIPTION
You can't "handsup" on bikes and motorcycles since the animation is bugged when on those vehicle. Also, on motorcycles you can use "X" to do other things like use a melee weapon to hit others, etc. It was hard to use "X" on bikes since it's stopped steering and the animation was bugged :(