### PR TITLE
Removed Ped Scenario native

### DIFF
--- a/client/density.lua
+++ b/client/density.lua
@@ -3,7 +3,6 @@ Citizen.CreateThread(function()
 		SetVehicleDensityMultiplierThisFrame(0.05)
 	    SetPedDensityMultiplierThisFrame(1.0)
 	    SetParkedVehicleDensityMultiplierThisFrame(1.0)
-		SetScenarioPedDensityMultiplierThisFrame(0.0, 0.0)
 
 		Citizen.Wait(3)
 	end


### PR DESCRIPTION
This native removes all scenarios from happening. This includes peds hanging out around restaurants, walking dogs, and all of wildlife spawning. 

Removing the native will bring this all back.