### PR TITLE
Update vehiclepush.lua

### DIFF
--- a/client/vehiclepush.lua
+++ b/client/vehiclepush.lua
@@ -47,7 +47,7 @@ CreateThread(function()
             local ped = PlayerPedId()
             local vehClass = GetVehicleClass(Vehicle.Vehicle)
 
-            if IsVehicleSeatFree(Vehicle.Vehicle, -1) and GetVehicleEngineHealth(Vehicle.Vehicle) <= Config.DamageNeeded then
+            if IsVehicleSeatFree(Vehicle.Vehicle, -1) and GetVehicleEngineHealth(Vehicle.Vehicle) <= Config.DamageNeeded and GetVehicleEngineHealth(Vehicle.Vehicle) >= 0 then
                 if vehClass ~= 13 or vehClass ~= 14 or vehClass ~= 15 or vehClass ~= 16 then
                     DrawText3Ds(Vehicle.Coords.x, Vehicle.Coords.y, Vehicle.Coords.z, 'Press [~g~SHIFT~w~] and [~g~E~w~] to push the vehicle')
                 end


### PR DESCRIPTION
Update so you cannot push completely exploded vehicles. I did test the vehicle engine health, and when my car was disabled after ramming it into things several times, the engine health was at 50. If the car was exploded, it goes into a negative number, going down to -4000 where it stops. So this fix does not allow people to push vehicles that have been exploded.

Will fix Issue #116 that does not actually have an error at all