### PR TITLE
bike/glitchy anim fix

### DIFF
--- a/client/noshuff.lua
+++ b/client/noshuff.lua
@@ -11,10 +11,11 @@ CreateThread(function()
                 if GetPedInVehicleSeat(veh, false, 0) == ped then
                     if GetIsTaskActive(ped, 165) then
                         SetPedIntoVehicle(ped, veh, 0)
+                        SetPedConfigFlag(ped, 184, true)
                     end
                 end
             end
-        Wait(10)
+        Wait(5)
     end
 end)
 


### PR DESCRIPTION
this change retains the ability of a ped to enter a passenger seat without shuffling, but gets rid of the glitchy animation where they attempt to start shuffling and are stopped by the script. places the ped into the vehicle once when they first attempt to shuffle, then sets the flag to disable their attempt to shuffle.