### PR TITLE
fix to /shuff command

### DIFF
--- a/client/noshuff.lua
+++ b/client/noshuff.lua
@@ -1,7 +1,4 @@
 local disableShuffle = true
-function disableSeatShuffle(flag)
-	disableShuffle = flag
-end
 
 CreateThread(function()
     while true do
@@ -20,10 +17,12 @@ CreateThread(function()
 end)
 
 RegisterNetEvent('SeatShuffle', function()
-	if IsPedInAnyVehicle(PlayerPedId(), false) then
-		disableSeatShuffle(false)
-		Wait(5000)
-		disableSeatShuffle(true)
+    local ped = PlayerPedId()
+	if IsPedInAnyVehicle(ped, false) then
+		disableShuffle = false
+        SetPedConfigFlag(ped, 184, false)
+        Wait(3000)
+        disableShuffle = true
 	else
 		CancelEvent()
 	end


### PR DESCRIPTION
minor change to how the shuff command works with the fix to noshuff to prevent glitchy animations. now removes the config flag temporarily and sets disableShuffle to false so that the script allows the player ped to shuffle into the driver seat.