### PR TITLE
Fixes Harness Inventory Metadata

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -20,13 +20,18 @@ end)
 RegisterNetEvent('equip:harness', function(item)
     local src = source
     local Player = QBCore.Functions.GetPlayer(src)
-    if Player.PlayerData.items[item.slot].info.uses == 1 then
+    
+    if Player.PlayerData.items[item.slot].info.uses == nil then
+        Player.PlayerData.items[item.slot].info.uses = 19
+        Player.Functions.SetInventory(Player.PlayerData.items)
+    elseif Player.PlayerData.items[item.slot].info.uses == 1 then
         TriggerClientEvent("inventory:client:ItemBox", src, QBCore.Shared.Items['harness'], "remove")
         Player.Functions.RemoveItem('harness', 1)
     else
         Player.PlayerData.items[item.slot].info.uses = Player.PlayerData.items[item.slot].info.uses - 1
         Player.Functions.SetInventory(Player.PlayerData.items)
     end
+    print(Player.PlayerData.items[item.slot].info.uses)
 end)
 
 RegisterNetEvent('seatbelt:DoHarnessDamage', function(hp, data)


### PR DESCRIPTION
The metadata "uses" is not set when a harness is placed in a players inventory.
This checks if the metadata "uses" is nil and if true then it sets uses to 19.
This fixes the harnesses so they only have 20 uses and also fixes the server side exception as shown below.
"[script:qb-smallresou] SCRIPT ERROR: @qb-smallresources/server/main.lua:39: attempt to perform arithmetic on a nil value (field 'uses')"
![image](https://user-images.githubusercontent.com/43043270/177047599-9a2e9cfd-b492-4022-a9f8-3bc0759e5c44.png)
