### PR TITLE
HudComponents Config

### DIFF
--- a/client/hudcomponents.lua
+++ b/client/hudcomponents.lua
@@ -1,4 +1,4 @@
-local disableHudComponents = {1, 2, 3, 4, 7, 9, 13, 14, 19, 20, 21, 22}
+local disableHudComponents = Config.disableHudComponents
 local disableControls = {37}
 local displayAmmo = true
 

--- a/config.lua
+++ b/config.lua
@@ -12,6 +12,33 @@ Config.DefaultPrice = 20 -- Default price for the carwash
 Config.DirtLevel = 0.1 -- Threshold for the dirt level to be counted as dirty
 Config.DisableAmbience = false -- Disabled distance sirens, distance car alarms, etc
 
+-- Uncomment lines to disable the specified HUD component.
+-- Comment lines to enable the specified HUD component.
+Config.disableHudComponents = {
+	1,	-- WANTED_STARS
+	2,	-- WEAPON_ICON
+	3,	-- CASH
+	4,	-- MP_CASH
+  --5,	-- MP_MESSAGE
+  --6,	-- VEHICLE_NAME
+	7,	-- AREA_NAME
+  --8,	-- VEHICLE_CLASS
+	9,	-- STREET_NAME
+  --10,	-- HELP_TEXT
+  --11,	-- FLOATING_HELP_TEXT_1
+  --12,	-- FLOATING_HELP_TEXT_2
+	13,	-- CASH_CHANGE
+    14,	-- RETICLE
+  --15,	-- SUBTITLE_TEXT
+  --16,	-- RADIO_STATIONS
+  --17,	-- SAVING_GAME
+  --18,	-- GAME_STREAM
+	19,	-- WEAPON_WHEEL
+	20,	-- WEAPON_WHEEL_STATS
+	21,	-- HUD_COMPONENTS
+	22	-- HUD_WEAPONS
+}
+
 ConsumablesEat = {
     ["sandwich"] = math.random(35, 54),
     ["tosti"] = math.random(40, 50),


### PR DESCRIPTION
Added a configuration variable to set which HUD components are initially disabled and added descriptions of what can be disabled. Set the local variable from the config variable so it should not affect performance.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes