### PR TITLE
fix holster variant

### DIFF
--- a/client/weapdraw.lua
+++ b/client/weapdraw.lua
@@ -154,7 +154,7 @@ RegisterNetEvent('weapons:client:DrawWeapon', function()
                             SetCurrentPedWeapon(ped, newWeap, true)
 
                             if IsWeaponHolsterable(newWeap) then
-                                SetPedComponentVariation(ped, 7, currentHolster == 8 and 2 or currentHolster == 1 and 3 or currentHolster == 6 and 5, currentHolsterTexture, 2)
+                                SetPedComponentVariation(ped, 7, HolsterVariant, currentHolsterTexture, 2)
                             end
                             currWeapon = newWeap
                             Wait(300)
@@ -194,7 +194,7 @@ RegisterNetEvent('weapons:client:DrawWeapon', function()
                             SetCurrentPedWeapon(ped, newWeap, true)
 
                             if IsWeaponHolsterable(newWeap) then
-                                SetPedComponentVariation(ped, 7, currentHolster == 8 and 2 or currentHolster == 1 and 3 or currentHolster == 6 and 5, currentHolsterTexture, 2)
+                                SetPedComponentVariation(ped, 7, HolsterVariant, currentHolsterTexture, 2)
                             end
 
                             Wait(500)
@@ -227,7 +227,7 @@ RegisterNetEvent('weapons:client:DrawWeapon', function()
                             SetCurrentPedWeapon(ped, newWeap, true)
 
                             if IsWeaponHolsterable(newWeap) then
-                                SetPedComponentVariation(ped, 7, currentHolster == 8 and 2 or currentHolster == 1 and 3 or currentHolster == 6 and 5, currentHolsterTexture, 2)
+                                SetPedComponentVariation(ped, 7, HolsterVariant, currentHolsterTexture, 2)
                             end
 
                             currWeapon = newWeap


### PR DESCRIPTION
When you choose different holstervariant then the selected ones it will remove holster after first use.
This way it will set to your default holster again when the weapon is pulled out.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? YES
- Does your code fit the style guidelines? YES
- Does your PR fit the contribution guidelines? YES
