### PR TITLE
no handsup if dead or last stand

### DIFF
--- a/client/handsup.lua
+++ b/client/handsup.lua
@@ -1,3 +1,5 @@
+QBCore = exports["qb-core"]:GetCoreObject()
+
 local animDict = "missminuteman_1ig_2"
 local anim = "handsup_base"
 local handsup = false
@@ -10,15 +12,21 @@ RegisterCommand('hu', function()
             Wait(10)
         end
     end
-    handsup = not handsup
-    if exports['qb-policejob']:IsHandcuffed() then return end
-    if handsup then
-        TaskPlayAnim(ped, animDict, anim, 8.0, 8.0, -1, 50, 0, false, false, false)
-        exports['qb-smallresources']:addDisableControls(Config.disableHandsupControls)
-    else
-        ClearPedTasks(ped)
-        exports['qb-smallresources']:removeDisableControls(Config.disableHandsupControls)
-    end
+
+    -- We verify if the character is dead or in last stand or handcuffed.
+    QBCore.Functions.GetPlayerData(function(PlayerData)
+        if PlayerData.metadata["isdead"] or exports['qb-policejob']:IsHandcuffed() or PlayerData.metadata["inlaststand"] then
+            return
+        end
+        handsup = not handsup
+        if handsup then
+            TaskPlayAnim(ped, animDict, anim, 8.0, 8.0, -1, 50, 0, false, false, false)
+            exports['qb-smallresources']:addDisableControls(Config.disableHandsupControls)
+        else
+            ClearPedTasks(ped)
+            exports['qb-smallresources']:removeDisableControls(Config.disableHandsupControls)
+        end
+    end)
 end, false)
 
 exports('getHandsup', function() return handsup end)


### PR DESCRIPTION
handsup
In addition to not being able to raise his hand when handcuffed, also not being able to raise his hand when he is in last stand or dead.

**Describe Pull request**
I added that you can avoid raising your hand when the character is dead or in last stand, I think it helps to avoid the annoying spam of raising your arms many times when the character is on the ground.



**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
