### PR TITLE
FIX Issue #313, #327, #321 and #324

### DIFF
--- a/client/consumables.lua
+++ b/client/consumables.lua
@@ -6,6 +6,7 @@ local ParachuteEquiped = false
 local currentVest = nil
 local currentVestTexture = nil
 local healing = false
+local ParachuteRemoveData = { outfitData = { ["bag"] = { item = 0, texture = 0} } }
 
 -- Functions
 RegisterNetEvent('QBCore:Client:UpdateObject', function()
@@ -409,14 +410,9 @@ RegisterNetEvent('consumables:client:ResetParachute', function()
         }, {}, {}, {}, function() -- Done
             local ped = PlayerPedId()
             TriggerEvent("inventory:client:ItemBox", QBCore.Shared.Items["parachute"], "add")
-            local ParachuteRemoveData = {
-                outfitData = {
-                    ["bag"] = { item = 0, texture = 0} -- Removing Parachute Clothing
-                }
-            }
             TriggerEvent('qb-clothing:client:loadOutfit', ParachuteRemoveData)
             TaskPlayAnim(ped, "clothingshirt", "exit", 8.0, 1.0, -1, 49, 0, false, false, false)
-            TriggerServerEvent("qb-consumables:server:AddParachute")
+            TriggerServerEvent("consumables:server:AddParachute")
             ParachuteEquiped = false
         end)
     else
@@ -517,3 +513,15 @@ function AlcoholLoop()
         end)
     end
 end
+
+Citizen.CreateThread(function()
+    while true do
+        local ped = PlayerPedId()
+        local parachuteState = GetPedParachuteState(ped)
+        if parachuteState == 3 then
+            Wait(2300)
+            TriggerEvent('qb-clothing:client:loadOutfit', ParachuteRemoveData)
+        end
+        Citizen.Wait(0)
+    end
+end)

--- a/client/consumables.lua
+++ b/client/consumables.lua
@@ -416,7 +416,7 @@ RegisterNetEvent('consumables:client:ResetParachute', function()
             }
             TriggerEvent('qb-clothing:client:loadOutfit', ParachuteRemoveData)
             TaskPlayAnim(ped, "clothingshirt", "exit", 8.0, 1.0, -1, 49, 0, false, false, false)
-            TriggerServerEvent("qb-smallpenis:server:AddParachute")
+            TriggerServerEvent("qb-consumables:server:AddParachute")
             ParachuteEquiped = false
         end)
     else

--- a/client/handsup.lua
+++ b/client/handsup.lua
@@ -1,7 +1,8 @@
+QBCore = exports["qb-core"]:GetCoreObject()
+
 local animDict = "missminuteman_1ig_2"
 local anim = "handsup_base"
 local handsup = false
-
 RegisterCommand('hu', function()
     local ped = PlayerPedId()
     if not HasAnimDictLoaded(animDict) then
@@ -10,15 +11,20 @@ RegisterCommand('hu', function()
             Wait(10)
         end
     end
-    handsup = not handsup
-    if exports['qb-policejob']:IsHandcuffed() then return end
-    if handsup then
-        TaskPlayAnim(ped, animDict, anim, 8.0, 8.0, -1, 50, 0, false, false, false)
-        exports['qb-smallresources']:addDisableControls(Config.disableHandsupControls)
-    else
-        ClearPedTasks(ped)
-        exports['qb-smallresources']:removeDisableControls(Config.disableHandsupControls)
-    end
+            -- We verify if the character is dead or in last stand or handcuffed.
+    QBCore.Functions.GetPlayerData(function(PlayerData)
+        if PlayerData.metadata["isdead"] or exports['qb-policejob']:IsHandcuffed() or PlayerData.metadata["inlaststand"] then
+            return
+        end
+        handsup = not handsup
+        if handsup then
+            TaskPlayAnim(ped, animDict, anim, 8.0, 8.0, -1, 50, 0, false, false, false)
+            exports['qb-smallresources']:addDisableControls(Config.disableHandsupControls)
+        else
+            ClearPedTasks(ped)
+            exports['qb-smallresources']:removeDisableControls(Config.disableHandsupControls)
+        end
+    end)
 end, false)
 
 exports('getHandsup', function() return handsup end)

--- a/client/handsup.lua
+++ b/client/handsup.lua
@@ -1,8 +1,10 @@
+
 QBCore = exports["qb-core"]:GetCoreObject()
 
 local animDict = "missminuteman_1ig_2"
 local anim = "handsup_base"
 local handsup = false
+
 RegisterCommand('hu', function()
     local ped = PlayerPedId()
     if not HasAnimDictLoaded(animDict) then
@@ -11,9 +13,9 @@ RegisterCommand('hu', function()
             Wait(10)
         end
     end
-            -- We verify if the character is dead or in last stand or handcuffed.
+            -- We verify if the character is dead or in last stand or handcuffed or in bed
     QBCore.Functions.GetPlayerData(function(PlayerData)
-        if PlayerData.metadata["isdead"] or exports['qb-policejob']:IsHandcuffed() or PlayerData.metadata["inlaststand"] then
+        if PlayerData.metadata["isdead"] or exports['qb-policejob']:IsHandcuffed() or PlayerData.metadata["inlaststand"] or exports['qb-ambulancejob']:getisInHospitalBed() == true then
             return
         end
         handsup = not handsup

--- a/client/hudcomponents.lua
+++ b/client/hudcomponents.lua
@@ -27,12 +27,20 @@ CreateThread(function()
             HideHudComponentThisFrame(disableHudComponents[i])
         end
 
+        -- Check for sniper rifle
+        local currentWeapon = GetSelectedPedWeapon(PlayerPedId())
+        if currentWeapon == GetHashKey("WEAPON_SNIPERRIFLE") or currentWeapon == GetHashKey("WEAPON_MARKSMANRIFLE") or currentWeapon == GetHashKey("WEAPON_MARKSMANRIFLE_MK2") or currentWeapon == GetHashKey("WEAPON_HEAVYSNIPER") then
+            ShowHudComponentThisFrame(14)
+        else
+            HideHudComponentThisFrame(14)
+        end
+
         for i = 1, #disableControls do
             DisableControlAction(2, disableControls[i], true)
         end
 
         DisplayAmmoThisFrame(displayAmmo)
-        
+
         -- Density
 
         SetParkedVehicleDensityMultiplierThisFrame(Config.Density['parked'])

--- a/server/consumables.lua
+++ b/server/consumables.lua
@@ -103,7 +103,7 @@ QBCore.Commands.Add("resetparachute", "Resets Parachute", {}, false, function(so
     TriggerClientEvent("consumables:client:ResetParachute", source)
 end)
 
-RegisterNetEvent('qb-consumables:server:AddParachute', function()
+RegisterNetEvent('consumables:server:AddParachute', function()
     local Player = QBCore.Functions.GetPlayer(source)
 
     if not Player then return end

--- a/server/consumables.lua
+++ b/server/consumables.lua
@@ -103,7 +103,7 @@ QBCore.Commands.Add("resetparachute", "Resets Parachute", {}, false, function(so
     TriggerClientEvent("consumables:client:ResetParachute", source)
 end)
 
-RegisterNetEvent('qb-smallpenis:server:AddParachute', function()
+RegisterNetEvent('qb-consumables:server:AddParachute', function()
     local Player = QBCore.Functions.GetPlayer(source)
 
     if not Player then return end


### PR DESCRIPTION
**Describe Pull request**
Added the option to activate the reticle with native ShowHudComponentThisFrame only when using a sniper rifle.
https://docs.fivem.net/natives/?_0x0B4DF1FA60C0E664
![image](https://user-images.githubusercontent.com/73045761/211857913-84596699-0b32-4243-8b68-151acdd9a2dd.png)

If your PR is to fix an issue mention that issue here
#313 

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes

Add  new commits 
4be88ba5a4b7dc7e5a04b99ec1b00842ca7bd75b
To fix #327  and #321 

Describe Pull request
Fix title "qb-smallpenis:server:AddParachute" To "consumables:server:AddParachute"

Add a thread to get the current state of the player's parachute at any time. You can use an if condition to check if the parachute state is 3: Falling to doom. and if so, call TriggerEvent('qb-clothing:client:loadOutfit', ParachuteRemoveData) to remove the prop from the player's parachute.

Questions (please complete the following information):

Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
Does your code fit the style guidelines? yes
Does your PR fit the contribution guidelines? yes


Move PR  https://github.com/qbcore-framework/qb-smallresources/pull/324 here
