### PR TITLE
Add AFK Timer in Character Selection

### DIFF
--- a/client/afk.lua
+++ b/client/afk.lua
@@ -68,6 +68,24 @@ CreateThread(function()
                 end
                 prevPos = currentPos
             end
+        else
+            if checkUser then
+                if time then
+                    if time > 0 then
+                        local _type = timeMinutes[tostring(time)]
+                        if _type == 'minutes' then
+                            QBCore.Functions.Notify(Lang:t('afk.will_kick') .. math.ceil(time / 60) .. Lang:t('afk.time_minutes'), 'error', 10000)
+                        elseif _type == 'seconds' then
+                            QBCore.Functions.Notify(Lang:t('afk.will_kick') .. time .. Lang:t('afk.time_seconds'), 'error', 10000)
+                            end
+                        time -= 10
+                    else
+                        TriggerServerEvent('KickForAFK')
+                    end
+                else
+                    time = Config.AFK.secondsUntilKickCharacterSelection
+                end
+            end
         end
     end
 end)

--- a/config.lua
+++ b/config.lua
@@ -9,7 +9,7 @@ Config.AFK = {
         ['admin'] = true,
         ['god'] = true
     },
-    secondsUntilKick = 1800 -- AFK Kick Time Limit (in seconds)
+    secondsUntilKick = 1800, -- AFK Kick Time Limit (in seconds)
     secondsUntilKickInCharacterSelection = 600 -- AFK Kick Time Limit While Player is in the Character Selector (in seconds)
 }
 

--- a/config.lua
+++ b/config.lua
@@ -10,6 +10,7 @@ Config.AFK = {
         ['god'] = true
     },
     secondsUntilKick = 1800 -- AFK Kick Time Limit (in seconds)
+    secondsUntilKickInCharacterSelection = 600 -- AFK Kick Time Limit While Player is in the Character Selector (in seconds)
 }
 
 Config.Binoculars = {


### PR DESCRIPTION
**Describe Pull request**
Implements suggestion brought up in #281 

This PR aims to add a configurable afk timer for players in the character selection screen. This also accounts for the time after the player selects a character and sits in the "select location" screen. The timer only stops when they spawn in on their character. Before this change, there was no afk timer for players who were not currently spawned into a character which subsequently allowed them to remain idle on the server for any period of time.

_I am also open to hearing feedback regarding the default AFK time I created._ 

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes]
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
