### PR TITLE
[ENHANCEMENT] Add blacklist for `cargoplane2`

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -214,6 +214,7 @@ Config.BlacklistedVehs = {
     [`rrocket`] = true,
     [`ruiner2`] = true,
     [`deluxo`] = true,
+    [`cargoplane2`] = true,
 }
 
 Config.BlacklistedPeds = {


### PR DESCRIPTION
**Describe Pull request**
Added the new **cargoplane2** which was added in the newest gta update to the blacklisted vehicle list
https://gtacars.net/gta5/cargoplane2

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
- yes
- Does your code fit the style guidelines? [yes/no]
- yes
- Does your PR fit the contribution guidelines? [yes/no]
- yes
