### PR TITLE
Batch post logs

### DIFF
--- a/server/logs.lua
+++ b/server/logs.lua
@@ -59,11 +59,10 @@ local logQueue = {}
 RegisterNetEvent('qb-log:server:CreateLog', function(name, title, color, message, tagEveryone)
     local tag = tagEveryone or false
     local webHook = Webhooks[name] or Webhooks['default']
-    local colorCode = Colors[color] or Colors['default']
     local embedData = {
         {
             ['title'] = title,
-            ['color'] = colorCode,
+            ['color'] = Colors[color] or Colors['default'],
             ['footer'] = {
                 ['text'] = os.date('%c'),
             },

--- a/server/logs.lua
+++ b/server/logs.lua
@@ -54,13 +54,16 @@ local Colors = { -- https://www.spycolor.com/
     ["lightgreen"] = 65309,
 }
 
+local logQueue = {}
+
 RegisterNetEvent('qb-log:server:CreateLog', function(name, title, color, message, tagEveryone)
     local tag = tagEveryone or false
     local webHook = Webhooks[name] or Webhooks['default']
+    local colorCode = Colors[color] or Colors['default']
     local embedData = {
         {
             ['title'] = title,
-            ['color'] = Colors[color] or Colors['default'],
+            ['color'] = colorCode,
             ['footer'] = {
                 ['text'] = os.date('%c'),
             },
@@ -71,10 +74,44 @@ RegisterNetEvent('qb-log:server:CreateLog', function(name, title, color, message
             },
         }
     }
-    PerformHttpRequest(webHook, function() end, 'POST', json.encode({ username = 'QB Logs', embeds = embedData}), { ['Content-Type'] = 'application/json' })
-    Citizen.Wait(100)
-    if tag then
-        PerformHttpRequest(webHook, function() end, 'POST', json.encode({ username = 'QB Logs', content = '@everyone'}), { ['Content-Type'] = 'application/json' })
+    
+    if not logQueue[name] then
+        logQueue[name] = {}
+    end
+    
+    table.insert(logQueue[name], {webhook = webHook, data = embedData})
+    
+    if #logQueue[name] >= 10 then
+        local postData = { username = 'QB Logs', embeds = {} }
+        
+        for i = 1, #logQueue[name] do
+            table.insert(postData.embeds, logQueue[name][i].data[1])
+        end
+        
+        PerformHttpRequest(logQueue[name][1].webhook, function() end, 'POST', json.encode(postData), { ['Content-Type'] = 'application/json' })
+
+        logQueue[name] = {}
+    end
+end)
+
+Citizen.CreateThread(function()
+    local timer = 0
+    while true do        
+        Citizen.Wait(1000)
+        timer = timer + 1
+        if timer >= 60 then -- If 60 seconds have passed, post the logs
+            timer = 0
+            for name, queue in pairs(logQueue) do
+                if #queue > 0 then
+                    local postData = { username = 'QB Logs', embeds = {} }
+                    for i = 1, #queue do
+                        table.insert(postData.embeds, queue[i].data[1])
+                    end
+                    PerformHttpRequest(queue[1].webhook, function() end, 'POST', json.encode(postData), { ['Content-Type'] = 'application/json' })
+                    logQueue[name] = {}
+                end
+            end
+        end
     end
 end)
 


### PR DESCRIPTION
**Describe Pull request**
With a large player base the constant http requests to discord cause a rate limit on the discord server. This update will queue each log category to a total of 10 before posting to the webhook. 10 is the maximum amount of embeds allowed in one discord post. Logs will post every 60 seconds incase the queue does not meet the 10 required for posting.

If your PR is to fix an issue mention that issue here:
#368 - Consolidation of logs

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes] (Be honest)
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
