### PR TITLE
:bug: Fix: Close menu as soon as you exit the polyzone

### DIFF
--- a/client/teleports.lua
+++ b/client/teleports.lua
@@ -48,6 +48,7 @@ CreateThread(function()
                     end
                 else
                     ran = false
+                    exports['qb-menu']:closeMenu()
                 end
             end)
         end


### PR DESCRIPTION
If you decide to not use the teleport the menu remains open untill you bring the mouse pointer up and hit ESC. This way the menu will close as soon as you exit the polyzone that brought the menu up.

**Questions:**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? yes
- Does your code fit the style guidelines? yes
- Does your PR fit the contribution guidelines? yes
