### PR TITLE
🐎 Recoil on game event CEventGunShot instead of loop

### DIFF
--- a/client/recoil.lua
+++ b/client/recoil.lua
@@ -86,35 +86,34 @@ local recoils = {
     [`weapon_rayminigun`] = 0.3,
 }
 
-CreateThread(function()
-    while true do
-        local ped = PlayerPedId()
-        if IsPedShooting(ped) and not IsPedDoingDriveby(ped) then
-            local _, weap = GetCurrentPedWeapon(ped)
-            if recoils[weap] and recoils[weap] ~= 0 then
-                local tv = 0
-                if GetFollowPedCamViewMode() ~= 4 then
-                    repeat
-                        Wait(0)
-                        local p = GetGameplayCamRelativePitch()
-                        SetGameplayCamRelativePitch(p + 0.1, 0.2)
-                        tv += 0.1
-                    until tv >= recoils[weap]
+AddEventHandler("CEventGunShot", function (entities, eventEntity, args)
+    local ped = PlayerPedId()
+
+    if eventEntity ~= ped then return end
+    if IsPedDoingDriveby(ped) then return end
+    
+    local _, weap = GetCurrentPedWeapon(ped)
+    if recoils[weap] and recoils[weap] ~= 0 then
+        local tv = 0
+        if GetFollowPedCamViewMode() ~= 4 then
+            repeat
+                Wait(0)
+                local p = GetGameplayCamRelativePitch()
+                SetGameplayCamRelativePitch(p + 0.1, 0.2)
+                tv += 0.1
+            until tv >= recoils[weap]
+        else
+            repeat
+                Wait(0)
+                local p = GetGameplayCamRelativePitch()
+                if recoils[weap] > 0.1 then
+                    SetGameplayCamRelativePitch(p + 0.6, 1.2)
+                    tv += 0.6
                 else
-                    repeat
-                        Wait(0)
-                        local p = GetGameplayCamRelativePitch()
-                        if recoils[weap] > 0.1 then
-                            SetGameplayCamRelativePitch(p + 0.6, 1.2)
-                            tv += 0.6
-                        else
-                            SetGameplayCamRelativePitch(p + 0.016, 0.333)
-                            tv += 0.1
-                        end
-                    until tv >= recoils[weap]
+                    SetGameplayCamRelativePitch(p + 0.016, 0.333)
+                    tv += 0.1
                 end
-            end
+            until tv >= recoils[weap]
         end
-        Wait(0)
     end
 end)


### PR DESCRIPTION
**Describe Pull request**
This code is optimization only. Instead of looping at 0ms and checking for `IsPedShooting`, this handles the game event `CEventGunShot` that is triggered when a ped shoots.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? Yes
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes