### PR TITLE
Added a cooldown to jump spamming

### DIFF
--- a/client/jumpcooldown.lua
+++ b/client/jumpcooldown.lua
@@ -1,0 +1,35 @@
+-- Initialize variables
+local jumpCooldown = false
+local cooldownTime = 10 -- Cooldown time in seconds
+
+-- Cooldown function
+local function startJumpCooldown()
+    jumpCooldown = true
+    Citizen.CreateThread(function()
+        Citizen.Wait(cooldownTime * 1000)
+        jumpCooldown = false
+    end)
+end
+
+-- Main thread to handle jump key
+Citizen.CreateThread(function()
+    while true do
+        Citizen.Wait(0)
+        if IsControlJustPressed(0, 22) then
+            if not jumpCooldown then
+                TaskJump(PlayerPedId())
+                startJumpCooldown()
+            end
+        end
+    end
+end)
+
+-- Disable the default jump when cooldown is active
+Citizen.CreateThread(function()
+    while true do
+        Citizen.Wait(0)
+        if jumpCooldown then
+            DisableControlAction(0, 22, true)
+        end
+    end
+end)

--- a/client/jumpcooldown.lua
+++ b/client/jumpcooldown.lua
@@ -1,12 +1,13 @@
 -- Initialize variables
+local QBCore = exports['qb-core']:GetCoreObject()
 local jumpCooldown = false
-local cooldownTime = 10 -- Cooldown time in seconds
+local cooldownTime = Config.jumpCooldown
 
 -- Cooldown function
 local function startJumpCooldown()
     jumpCooldown = true
     Citizen.CreateThread(function()
-        Citizen.Wait(cooldownTime * 1000)
+        Citizen.Wait(cooldownTime * 1000) -- Wait for the cooldown time
         jumpCooldown = false
     end)
 end
@@ -15,11 +16,14 @@ end
 Citizen.CreateThread(function()
     while true do
         Citizen.Wait(0)
-        if IsControlJustPressed(0, 22) then
-            if not jumpCooldown then
-                TaskJump(PlayerPedId())
-                startJumpCooldown()
+        if not IsControlPressed(0, 25) then
+            if IsControlJustPressed(0, 22) then
+                if not jumpCooldown then
+                    TaskJump(PlayerPedId())
+                    startJumpCooldown()
+                end
             end
+        else
         end
     end
 end)
@@ -28,8 +32,12 @@ end)
 Citizen.CreateThread(function()
     while true do
         Citizen.Wait(0)
-        if jumpCooldown then
-            DisableControlAction(0, 22, true)
+        if not IsControlPressed(0, 25) then
+            if jumpCooldown then
+                DisableControlAction(0, 22, true)
+            end
+        else
+            EnableControlAction(0, 22, true)
         end
     end
 end)

--- a/config.lua
+++ b/config.lua
@@ -5,6 +5,7 @@ Config.PauseMapText = ''                                     -- Text shown above
 Config.HarnessUses = 20
 Config.DamageNeeded = 100.0                                  -- amount of damage till you can push your vehicle. 0-1000
 Config.Logging = 'discord'                                   -- fivemanage
+Config.jumpCooldown = 7                                      -- in seconds
 
 Config.AFK = {
     ignoredGroups = {


### PR DESCRIPTION
**Describe Pull request**
Players do multiple jumps when their ped runs out of stamina to run faster and was an issue in my community so this script will add a 7 seconds cooldown to jumps but doesn't affects the combat roll while pointing weapon.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes/no] (Be honest)
- Yes
- Does your code fit the style guidelines? [yes/no]
- Yes
- Does your PR fit the contribution guidelines? [yes/no]
Yes
