### PR TITLE
add Config.Disable.carRadio

### DIFF
--- a/client/ignore.lua
+++ b/client/ignore.lua
@@ -135,3 +135,9 @@ CreateThread(function()
         Wait(5)
     end
 end)
+
+RegisterNetEvent('QBCore:Client:EnteredVehicle', function(data)
+    if Config.Disable.carRadio then
+        SetVehRadioStation(data.vehicle, 'OFF')
+    end
+end)

--- a/config.lua
+++ b/config.lua
@@ -88,6 +88,7 @@ Config.Disable = {
     vestDrawable = false,                                         -- disables the vest equipped when using heavy armor
     pistolWhipping = true,                                        -- disables pistol whipping
     driveby = false,                                              -- disables driveby
+    carRadio = false                                              -- When set to true car radio will default to off when entering a vehicle.
 }
 
 Config.RelieveWeedStress = math.random(15, 20) -- stress relief amount (100 max)


### PR DESCRIPTION
The addition of Config.Disable.carRadio will allow server owners to decide whether the radio of a vehicle defaults to off on entry

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? No
- Does your code fit the style guidelines? Yes
- Does your PR fit the contribution guidelines? Yes

