### PR TITLE
fix(client\vehicletext): brand name text duplicate

### DIFF
--- a/client/vehicletext.lua
+++ b/client/vehicletext.lua
@@ -3,8 +3,11 @@ local QBCore = exports['qb-core']:GetCoreObject()
 CreateThread(function()
     for _, v in pairs(QBCore.Shared.Vehicles) do
         local text
-        if v.brand then
-            text = v.brand..' '..v.name
+        local name = string.lower(v.name)
+        local brand = string.lower(v.brand)
+        if v.brand and string.match(name, brand) then
+            local nameWithoutBrand = string.gsub(name, brand, "")
+            text = v.brand .. ' ' .. nameWithoutBrand
         else
             text = v.name
         end


### PR DESCRIPTION
This fixes the duplicate text when entering a car.

Issue:
![text](https://github.com/user-attachments/assets/7c0873d9-e15d-428b-b5f5-d327badbc391)

Example:
"Vapid, Vapid Sandler, Utility" becomes: "Vapid Sandler, Utility"