### PR TITLE
Disable handsup when dead, inlaststand or in vehicle.

### DIFF
--- a/client/handsup.lua
+++ b/client/handsup.lua
@@ -1,23 +1,35 @@
-local handsUp = false
+local animDict = "missminuteman_1ig_2"
+local anim = "handsup_base"
+local handsup = false
+local QBCore = exports['qb-core']:GetCoreObject()
 
 RegisterCommand(Config.HandsUp.command, function()
     local ped = PlayerPedId()
-    if not HasAnimDictLoaded('missminuteman_1ig_2') then
-        RequestAnimDict('missminuteman_1ig_2')
-        while not HasAnimDictLoaded('missminuteman_1ig_2') do
+    if QBCore.Functions.GetPlayerData().metadata['isdead'] then return end 
+    if IsPedInAnyVehicle(PlayerPedId(), false) then
+        -- Do nothing if the player is in a vehicle
+        return
+    end
+    if not HasAnimDictLoaded(animDict) then
+        RequestAnimDict(animDict)
+        while not HasAnimDictLoaded(animDict) do
             Wait(10)
         end
     end
-    handsUp = not handsUp
+    local PlayerData = QBCore.Functions.GetPlayerData()
+    if exports['qb-policejob']:IsHandcuffed() or PlayerData.metadata["isdead"] or PlayerData.metadata["inlaststand"] then
+        return
+    end
+    handsup = not handsup
     if exports['qb-policejob']:IsHandcuffed() then return end
-    if handsUp then
-        TaskPlayAnim(ped, 'missminuteman_1ig_2', 'handsup_base', 8.0, 8.0, -1, 50, 0, false, false, false)
-        exports['qb-smallresources']:addDisableControls(Config.HandsUp.controls)
+    if handsup then
+        TaskPlayAnim(ped, animDict, anim, 8.0, 8.0, -1, 50, 0, false, false, false)
+        exports['qb-smallresources']:addDisableControls(Config.Disable.controls)
     else
         ClearPedTasks(ped)
-        exports['qb-smallresources']:removeDisableControls(Config.HandsUp.controls)
+        exports['qb-smallresources']:removeDisableControls(Config.Disable.controls)
     end
 end, false)
 
 RegisterKeyMapping(Config.HandsUp.command, 'Hands Up', 'keyboard', Config.HandsUp.keybind)
-exports('getHandsup', function() return handsUp end)
+exports('getHandsup', function() return handsup end)


### PR DESCRIPTION
**Describe Pull request**
Fixes people spamming hands up when dead/inlaststand also makes it so you cant use handsup when inside a vehicle.

If your PR is to fix an issue mention that issue here

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? YES
- Does your code fit the style guidelines? YES
- Does your PR fit the contribution guidelines? YES
