### PR TITLE
Add HasSeatbeltOn export to seats.lua

### DIFF
--- a/client/seatbelt.lua
+++ b/client/seatbelt.lua
@@ -83,6 +83,14 @@ end
 
 exports("HasHarness", hasHarness)
 
+---Checks whether the player has their seatbelt on or not
+---@return boolean
+local function hasSeatbeltOn()
+    return seatbeltOn
+end
+
+exports("HasSeatbeltOn", hasSeatbeltOn)
+
 -- Ejection Logic
 
 RegisterNetEvent('QBCore:Client:EnteredVehicle', function()


### PR DESCRIPTION
**Describe Pull request**
Adds a simple `HasSeatBeltOn` export to the seatbelt.lua file.
This returns the state of the `seatbeltOn` variable that is maintained from this file.

This enables other scripts to use this for whatever they need.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? [yes]
- Does your code fit the style guidelines? [yes]
- Does your PR fit the contribution guidelines? [yes]
