### PR TITLE
Fixes the call to the hospital server event

### DIFF
--- a/server/consumables.lua
+++ b/server/consumables.lua
@@ -135,7 +135,7 @@ RegisterNetEvent('consumables:server:useHeavyArmor', function()
     if not Player then return end
     if not exports['qb-inventory']:RemoveItem(source, 'heavyarmor', 1, false, 'consumables:server:useHeavyArmor') then return end
     TriggerClientEvent('qb-inventory:client:ItemBox', source, QBCore.Shared.Items['heavyarmor'], 'remove')
-    TriggerClientEvent('hospital:server:SetArmor', source, 100)
+    TriggerEvent('hospital:server:SetArmor', 100)
     SetPedArmour(GetPlayerPed(source), 100)
 end)
 
@@ -144,7 +144,7 @@ RegisterNetEvent('consumables:server:useArmor', function()
     if not Player then return end
     if not exports['qb-inventory']:RemoveItem(source, 'armor', 1, false, 'consumables:server:useArmor') then return end
     TriggerClientEvent('qb-inventory:client:ItemBox', source, QBCore.Shared.Items['armor'], 'remove')
-    TriggerClientEvent('hospital:server:SetArmor', source, 75)
+    TriggerEvent('hospital:server:SetArmor', 75)
     SetPedArmour(GetPlayerPed(source), 75)
 end)
 


### PR DESCRIPTION
Fixes #293, fixes #455 

Also fixes [qb-ambulancejob/308](https://github.com/qbcore-framework/qb-ambulancejob/issues/308)

Sat and traced this back to it incorrectly trying to call a server event with a client method. This will now update the players armor metadata value correctly when they first use armor.

**Questions (please complete the following information):**
- Have you personally loaded this code into an updated qbcore project and checked all it's functionality? **Yes**
- Does your code fit the style guidelines? **Yes**
- Does your PR fit the contribution guidelines? **Yes**
