### PR TITLE
Better solution for exit animation

### DIFF
--- a/client/handsup.lua
+++ b/client/handsup.lua
@@ -14,7 +14,7 @@ RegisterCommand(Config.HandsUp.command, function()
         TaskPlayAnim(ped, 'missminuteman_1ig_2', 'handsup_base', 8.0, 8.0, -1, 50, 0, false, false, false)
         exports['qb-smallresources']:addDisableControls(Config.HandsUp.controls)
     else
-        ClearPedTasks(ped)
+        StopAnimTask(ped, 'missminuteman_1ig_2', 'handsup_base', 8.0)
         exports['qb-smallresources']:removeDisableControls(Config.HandsUp.controls)
     end
 end, false)


### PR DESCRIPTION
A small improvement to avoid unnecessary movement in the lower body when exiting the animation. Allowing them to sit and have their hands up, for example.

**Describe Pull request**
I've encountered an issue while deploying a mod to sit after circling around a little bit, the best solution was to avoid the too absolute ClearPedTask and just canceling the animation you run, will allow a better integration with third party mod i think. Nice work, by the way :)

**Questions (please complete the following information):**
- Yes, especially with a third party script for sitting
- Not checked but is a very minor change
- Does your PR fit the contribution guidelines? [yes/no]
